### PR TITLE
Add `IEventBus` method to check for any registered listeners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group "meteordevelopment"
-version "0.2.3"
+version "0.2.4"
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/src/main/java/meteordevelopment/orbit/EventBus.java
+++ b/src/main/java/meteordevelopment/orbit/EventBus.java
@@ -40,6 +40,12 @@ public class EventBus implements IEventBus {
     }
 
     @Override
+    public boolean isListening(Class<?> eventKlass) {
+        List<IListener> listeners = listenerMap.get(eventKlass);
+        return listeners != null && !listeners.isEmpty();
+    }
+
+    @Override
     public <T> T post(T event) {
         List<IListener> listeners = listenerMap.get(event.getClass());
 

--- a/src/main/java/meteordevelopment/orbit/IEventBus.java
+++ b/src/main/java/meteordevelopment/orbit/IEventBus.java
@@ -15,6 +15,13 @@ public interface IEventBus {
     void registerLambdaFactory(String packagePrefix, LambdaListener.Factory factory);
 
     /**
+     * Returns whether at least one event listener is currently registered for this event type.
+     * @param eventClass The event type to check for registered listeners.
+     * @return whether the event is being listened for
+     */
+    boolean isListening(Class<?> eventClass);
+
+    /**
      * Posts an event to all subscribed event listeners.
      * @param event Event to post
      * @param <T> Type of the event

--- a/src/main/java/meteordevelopment/orbit/IEventBus.java
+++ b/src/main/java/meteordevelopment/orbit/IEventBus.java
@@ -18,6 +18,7 @@ public interface IEventBus {
      * Returns whether at least one event listener is currently registered for this event type.
      * @param eventClass The event type to check for registered listeners.
      * @return whether the event is being listened for
+     * @since 0.2.4
      */
     boolean isListening(Class<?> eventClass);
 


### PR DESCRIPTION
Example use case:
```java
private void onChunkDeltaUpdate(ChunkDeltaUpdateS2CPacket packet) {
    if (EVENT_BUS.isListening(BlockUpdateEvent.class)) {
        packet.visitUpdates((blockPos, blockState) -> {
            EVENT_BUS.post(BlockUpdateEvent.get(blockPos, blockState));
        });
    }
}
```
This would make it be possible to:
1. Only read the packet data if there is currently an event listener registered.
2. Only read the packet data once if there are multiple event listeners registered.