### PR TITLE
Fix `ConsumerListener` generics

### DIFF
--- a/src/main/java/meteordevelopment/orbit/listeners/ConsumerListener.java
+++ b/src/main/java/meteordevelopment/orbit/listeners/ConsumerListener.java
@@ -29,7 +29,7 @@ public class ConsumerListener<T> implements IListener {
     }
 
     @Override
-    public Class<?> getTarget() {
+    public Class<T> getTarget() {
         return target;
     }
 

--- a/src/main/java/meteordevelopment/orbit/listeners/ConsumerListener.java
+++ b/src/main/java/meteordevelopment/orbit/listeners/ConsumerListener.java
@@ -8,17 +8,17 @@ import java.util.function.Consumer;
  * Listener that takes in a {@link java.util.function.Consumer}.
  */
 public class ConsumerListener<T> implements IListener {
-    private final Class<?> target;
+    private final Class<T> target;
     private final int priority;
     private final Consumer<T> executor;
 
-    public ConsumerListener(Class<?> target, int priority, Consumer<T> executor) {
+    public ConsumerListener(Class<T> target, int priority, Consumer<T> executor) {
         this.target = target;
         this.priority = priority;
         this.executor = executor;
     }
     
-    public ConsumerListener(Class<?> target, Consumer<T> executor) {
+    public ConsumerListener(Class<T> target, Consumer<T> executor) {
         this(target, EventPriority.MEDIUM, executor);
     }
 


### PR DESCRIPTION
Since the `Class<?> target` parameter of `ConsumerListener`'s constructors use wildcard types, it cannot infer the lambda type and doesn't let you access its members without casting.

Before:
![image](https://github.com/MeteorDevelopment/orbit/assets/32882447/e146a440-a9d5-4c2a-b6cb-36b4c89d46f9)

After:
![image](https://github.com/MeteorDevelopment/orbit/assets/32882447/45f1f5bf-49be-4b98-a980-1d9c3cd46993)

Note: It was possible to manually specify the parameter type to get around this (`new ConsumerListener<Event>(Event.class, Event::method)`), however this involves specifying the target type twice so it's not ideal.